### PR TITLE
Added Russian translation for tabs_options

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -83,6 +83,12 @@
     <string name="new_tab_title">[НОВАЯ ВКЛ.]</string>
     <string name="open_a_new_tab_here">Открыть новую вкладку тут</string>
     <string name="tabs">Вкладки</string>
+    <array name="tabs_options">
+        <item>Закрыть текущую</item>
+        <item>Закрыть все</item>
+        <item>Сдвинуть влево</item>
+        <item>Сдвинуть вправо</item>
+    </array>
     <string name="ssl_expired">Срок действия сертификата истек</string>
     <string name="ssl_idmismatch">Несоответствие имени хоста</string>
     <string name="ssl_date_invalid">Дата сертификата недействительна</string>


### PR DESCRIPTION
Added missed array with tabs_options to Russain stirngs.xml + translations for the objects of this array.
Before that, English strings was used by default.

Before:
![Screenshot_1615361533](https://user-images.githubusercontent.com/22594525/110594122-ffc00900-81ae-11eb-9252-38b38c078de3.png)

After:
![Screenshot_1615361696](https://user-images.githubusercontent.com/22594525/110594157-064e8080-81af-11eb-8099-434b20da1143.png)
