### PR TITLE
Fix: Zoom out button using disabled color when enabled

### DIFF
--- a/app/src/main/res/drawable/ic_zoom_out_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_zoom_out_black_24dp.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14zM7,9h5v1L7,10z"
-      android:fillColor="@color/day_night_disabled_icon_color"/>
+      android:fillColor="@color/day_night_icon_color"/>
 </vector>


### PR DESCRIPTION
The icon on the button for zooming out stays gray (disabled color) even when zoomed in, when the button is enabled (and functioning) and should be black (enabled color).