### PR TITLE
Fix history not clear issue

### DIFF
--- a/app/src/main/java/com/phlox/tvwebbrowser/activity/history/HistoryActivity.kt
+++ b/app/src/main/java/com/phlox/tvwebbrowser/activity/history/HistoryActivity.kt
@@ -82,6 +82,10 @@ class HistoryActivity : AppCompatActivity(), AdapterView.OnItemClickListener, Ad
                 .setMessage(if (deleteAll) R.string.msg_delete_history_all else R.string.msg_delete_history)
                 .setPositiveButton(android.R.string.ok) { _, _ ->
                     lifecycleScope.launch(Dispatchers.Main) {
+                        if (deleteAll) {
+                            AppDatabase.db.historyDao().deleteWhereTimeLessThan(Long.MAX_VALUE)
+                            return@launch
+                        }
                         AppDatabase.db.historyDao().delete(*items.toTypedArray())
                         adapter!!.remove(items)
                     }

--- a/app/src/main/java/com/phlox/tvwebbrowser/activity/history/HistoryActivity.kt
+++ b/app/src/main/java/com/phlox/tvwebbrowser/activity/history/HistoryActivity.kt
@@ -75,8 +75,7 @@ class HistoryActivity : AppCompatActivity(), AdapterView.OnItemClickListener, Ad
     }
 
     private fun showDeleteDialog(deleteAll: Boolean) {
-        val items = if (deleteAll) adapter!!.items else adapter!!.selectedItems
-        if (items.isEmpty()) return
+        if (adapter!!.items.isEmpty() || (adapter!!.selectedItems.isEmpty() && !deleteAll)) return
         AlertDialog.Builder(this)
                 .setTitle(R.string.delete)
                 .setMessage(if (deleteAll) R.string.msg_delete_history_all else R.string.msg_delete_history)
@@ -84,10 +83,11 @@ class HistoryActivity : AppCompatActivity(), AdapterView.OnItemClickListener, Ad
                     lifecycleScope.launch(Dispatchers.Main) {
                         if (deleteAll) {
                             AppDatabase.db.historyDao().deleteWhereTimeLessThan(Long.MAX_VALUE)
-                            return@launch
+                            adapter!!.erase()
+                        } else {
+                            AppDatabase.db.historyDao().delete(*(adapter!!.selectedItems).toTypedArray())
+                            adapter!!.remove(adapter!!.selectedItems)
                         }
-                        AppDatabase.db.historyDao().delete(*items.toTypedArray())
-                        adapter!!.remove(items)
                     }
                 }
                 .setNeutralButton(android.R.string.cancel) { dialogInterface, i -> }


### PR DESCRIPTION
### Issue: 
https://github.com/shark-yn/tv-bro/issues/1 
### Cause: 
"Clear" only delete history items that are stored in HistoryAdaptor, which usually doesn't load all history items from DB
### Test:  
Tested selected deletion and all deletion, work well