### PR TITLE
Add button to block popups (PoC)

### DIFF
--- a/app/src/main/java/com/phlox/tvwebbrowser/activity/main/view/WebViewEx.kt
+++ b/app/src/main/java/com/phlox/tvwebbrowser/activity/main/view/WebViewEx.kt
@@ -60,6 +60,7 @@ class WebViewEx(context: Context, val callback: Callback, val jsInterface: Andro
     var trustSsl: Boolean = false
     private var currentOriginalUrl: Uri? = null
     var blockedAds = 0
+    var blockedPopups = 0
     private val uiHandler = Handler(Looper.getMainLooper())
     private var optimalPageFavIcon: Bitmap? = null
 
@@ -82,7 +83,9 @@ class WebViewEx(context: Context, val callback: Callback, val jsInterface: Andro
         fun onPageCertificateError(url: String?)
         fun isAdBlockingEnabled(): Boolean
         fun isAd(request: WebResourceRequest, baseUri: Uri): Boolean
+        fun isPopupBlockingEnabled(): Boolean
         fun onBlockedAdsCountChanged(blockedAds: Int)
+        fun onBlockedPopupsCountChanged(blockedPopups: Int)
         fun onCreateWindow(dialog: Boolean, userGesture: Boolean): WebViewEx?
         fun closeWindow(window: WebView)
         fun onDownloadStart(url: String, userAgent: String, contentDisposition: String, mimetype: String?, contentLength: Long)
@@ -292,6 +295,11 @@ class WebViewEx(context: Context, val callback: Callback, val jsInterface: Andro
             }
 
             override fun onCreateWindow(view: WebView, isDialog: Boolean, isUserGesture: Boolean, resultMsg: Message): Boolean {
+                if (callback.isPopupBlockingEnabled()) {
+                    blockedPopups++;
+                    callback.onBlockedPopupsCountChanged(blockedPopups);
+                    return false;
+                }
                 if (callback.isAdBlockingEnabled() && !isUserGesture) {
                     blockedAds++
                     callback.onBlockedAdsCountChanged(blockedAds)
@@ -340,6 +348,7 @@ class WebViewEx(context: Context, val callback: Callback, val jsInterface: Andro
                 currentOriginalUrl = Uri.parse(url)
                 callback.onPageStarted(url)
                 blockedAds = 0
+                blockedPopups = 0
                 callback.onBlockedAdsCountChanged(blockedAds)
             }
 

--- a/app/src/main/java/com/phlox/tvwebbrowser/model/WebTabState.kt
+++ b/app/src/main/java/com/phlox/tvwebbrowser/model/WebTabState.kt
@@ -46,6 +46,7 @@ data class WebTabState(@PrimaryKey(autoGenerate = true)
                        @ColumnInfo(name = "wv_state_file")
                        var wvStateFileName: String? = null,
                        var adblock: Boolean? = null,
+                       var popupblock: Boolean? = null,
                        var scale: Float? = null) {
     companion object {
         const val TAB_THUMBNAILS_DIR = "tabthumbs"

--- a/app/src/main/java/com/phlox/tvwebbrowser/singleton/AppDatabase.kt
+++ b/app/src/main/java/com/phlox/tvwebbrowser/singleton/AppDatabase.kt
@@ -10,7 +10,7 @@ import com.phlox.tvwebbrowser.TVBro
 import com.phlox.tvwebbrowser.model.*
 import com.phlox.tvwebbrowser.model.dao.*
 
-@Database(entities = [Download::class, FavoriteItem::class, HistoryItem::class, WebTabState::class], version = 15/*, exportSchema = true*/)
+@Database(entities = [Download::class, FavoriteItem::class, HistoryItem::class, WebTabState::class], version = 16/*, exportSchema = true*/)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun downloadDao(): DownloadDao
     abstract fun historyDao(): HistoryDao
@@ -116,6 +116,13 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_15_16 = object : Migration(15, 16) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE history\n" +
+                        "ADD popupblock INTEGER;")
+            }
+        }
+
         private fun createAdBlockListTable(db: SupportSQLiteDatabase) {
             db.execSQL("CREATE TABLE IF NOT EXISTS 'adblocklist' ('id' INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, 'type' INTEGER NOT NULL, 'value' TEXT NOT NULL)")
             db.execSQL("CREATE INDEX IF NOT EXISTS 'type_value_idx' ON 'adblocklist' ('type', 'value')")
@@ -154,7 +161,7 @@ abstract class AppDatabase : RoomDatabase() {
                 AppDatabase::class.java, "main.db"
             ).addMigrations(MIGRATION_1_2, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_8, MIGRATION_8_9,
                 MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
-                MIGRATION_14_15).build()
+                MIGRATION_14_15, MIGRATION_15_16).build()
         }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -182,9 +182,24 @@
             android:layout_marginTop="3dp"
             android:layout_marginBottom="3dp"
             android:layout_marginEnd="3dp"
-            app:layout_constraintEnd_toStartOf="@+id/ibHome"
+            app:layout_constraintEnd_toStartOf="@+id/ibPopupBlock"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@+id/ibZoomOut"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <ImageButton
+            android:id="@+id/ibPopupBlock"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/button_bg_selector"
+            android:contentDescription="@string/toggle_ads_blocking"
+            android:src="@drawable/ic_adblock_on"
+            android:layout_marginTop="3dp"
+            android:layout_marginBottom="3dp"
+            android:layout_marginEnd="3dp"
+            app:layout_constraintEnd_toStartOf="@+id/ibHome"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@+id/ibAdBlock"
             app:layout_constraintBottom_toBottomOf="parent"/>
 
         <ImageButton
@@ -199,7 +214,7 @@
             android:layout_marginBottom="3dp"
             android:layout_marginEnd="3dp"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toEndOf="@+id/ibAdBlock"
+            app:layout_constraintStart_toEndOf="@+id/ibPopupBlock"
             app:layout_constraintBottom_toBottomOf="parent"/>
 
         <TextView
@@ -212,6 +227,22 @@
             app:layout_constraintBottom_toTopOf="@+id/ibAdBlock"
             app:layout_constraintStart_toEndOf="@+id/ibAdBlock"
             app:layout_constraintEnd_toEndOf="@+id/ibAdBlock"
+            android:background="@drawable/gray_badge_bg"
+            android:gravity="center"
+            android:visibility="gone"
+            tools:visibility="visible"
+            tools:text="1" />
+
+        <TextView
+            android:id="@+id/tvBlockedPopupCounter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="20dp"
+            android:textSize="12sp"
+            app:layout_constraintTop_toTopOf="@+id/ibPopupBlock"
+            app:layout_constraintBottom_toTopOf="@+id/ibPopupBlock"
+            app:layout_constraintStart_toEndOf="@+id/ibPopupBlock"
+            app:layout_constraintEnd_toEndOf="@+id/ibPopupBlock"
             android:background="@drawable/gray_badge_bg"
             android:gravity="center"
             android:visibility="gone"


### PR DESCRIPTION
While trying to watch some TV shows on "alternative" sites I ran into the issue that theses sites kept opening ads in new tabs. They circumvent the `isUserGesture` restriction by putting an invisible element over the whole site that opens the new tab when it is clicked. 

Advanced adblockers like Ublock Origin for example solve this issue with complex filter rules that allow to block javascript like window.open on certain websites. Implementing support for such rules in Android WebView seems rather complicated, so I suggest implementing an option that allows to block sites from opening new tabs/popups.

Closes #95

The content of this pull request is unfinished and a proof of concept.

To let the user decide if popups should be blocked, I suggest putting a new button besides the "Block ads" button. Because I suck at designing icons I copied the icons of the "Block ads" button for now.
<img src="https://user-images.githubusercontent.com/2707930/205463927-ba4607c0-dcfc-4e2d-bef6-9e92643058ad.png">

Unlike the adblocker the popup blocker is disabled per default and needs to be enabled by the user explicitly.

Currently the state is tied to the tab. Ideally it would be tied to the host name of a website, so that when I enable it for a website, e.g. google.com, it will be remembered the next time I visit that website again. Unfortunately I am not familiar enough with Room to implement the necessary database changes for that.

Open tasks:
- [ ] Replace placeholder icons
- [ ] (optionally) Tie the decision to block popups to the host name instead of the tab.
