### PR TITLE
Move translatable strings to strings.xml (#108)

### DIFF
--- a/app/src/main/res/layout/dialog_favorites.xml
+++ b/app/src/main/res/layout/dialog_favorites.xml
@@ -48,7 +48,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="No bookmarks yet"
+        android:text="@string/no_bookmarks_yet"
         android:id="@+id/tvPlaceholder"
         android:textSize="20sp"
         android:paddingTop="20dp"

--- a/app/src/main/res/layout/dialog_new_favorite_item.xml
+++ b/app/src/main/res/layout/dialog_new_favorite_item.xml
@@ -89,7 +89,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="@drawable/button_bg_selector"
-            android:text="Cancel"
+            android:text="@string/cancel"
             android:id="@+id/btnCancel"
             android:layout_weight="1" />
 
@@ -97,7 +97,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="@drawable/button_bg_selector"
-            android:text="Done"
+            android:text="@string/done"
             android:id="@+id/btnDone"
             android:layout_weight="1" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,9 @@
     <string name="bookmarks">Bookmarks</string>
     <string name="add">Add</string>
     <string name="edit">Edit</string>
+    <string name="no_bookmarks_yet">No bookmarks yet</string>
     <string name="new_bookmark">New bookmark</string>
+    <string name="done">Done</string>
     <string name="title">Title</string>
     <string name="url" translatable="false">URL</string>
     <string name="search_history">Search history</string>


### PR DESCRIPTION
As reported in #108, these strings should be in strings.xml to make translating easier.