### PR TITLE
The "Open in new tab" option changes the URL to lowercase

### DIFF
--- a/app/src/main/java/com/phlox/tvwebbrowser/activity/main/view/WebViewEx.kt
+++ b/app/src/main/java/com/phlox/tvwebbrowser/activity/main/view/WebViewEx.kt
@@ -416,8 +416,8 @@ class WebViewEx(context: Context, val callback: Callback, val jsInterface: Andro
         if (s.startsWith("\"") && s.endsWith("\"")) {
             s = s.substring(1, s.length - 1)
         }
-        val url = s.toLowerCase(Locale.ROOT)
-        if (url.startsWith("http://") || url.startsWith("https://")) {
+        val url = s
+        if (url.startsWith("http://", true) || url.startsWith("https://", true)) {
             val anchor = View(context)
             val parent = parent as FrameLayout
             val lp = FrameLayout.LayoutParams(1, 1)


### PR DESCRIPTION
Opening any link in a new tab by holding the center D-Pad button and selecting "Open in new tab" changes the case of all characters in the URL to lower case.  In many cases this doesn't matter (e.g. [GitHub.com/MailYouLater](//GitHub.com/MailYouLater) & [github.com/mailyoulater](//github.com/mailyoulater) both work to reach the same content) however there are also cases where it causes problems (e.g. links to Wikipedia pages) and since I've been using TV Bro to look up some info in Wikipedia articles recently, I'm finding this issue to be quite annoying.

Xiaomi MiBox S
Android TV Version 9
TV Bro Version 1.7.2