### PR TITLE
Fix: Allow fallback for unknown URL schemes

### DIFF
--- a/app/src/main/java/com/phlox/tvwebbrowser/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/phlox/tvwebbrowser/activity/main/MainActivity.kt
@@ -1143,7 +1143,7 @@ open class MainActivity : AppCompatActivity(), ActionBar.Callback {
                     runOnUiThread {
                         Utils.showToast(applicationContext, getString(R.string.err_no_app_to_handle_url))
                     }
-                    false
+                    true
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "shouldOverrideUrlLoading: ", e)


### PR DESCRIPTION
This pull request addresses an issue where some videos fail to play on Android TV because the browser incorrectly handles custom URL schemes, preventing websites from executing their fallback playback mechanisms.

**The Problem**
On certain websites (e.g., fmovies), clicking the play button on a video first attempts to launch an external application via a custom URL scheme (such as `hobs://...`).

On Android mobile, if the corresponding app is not installed, the OS fails to handle the URL, but the browser gracefully ignores it. This allows the website's JavaScript to proceed with its fallback plan, which is to play the video directly within the browser's webview.

On Android TV, the current implementation behaves differently. When no app is found to handle the custom URL, the browser attempts to load the URL anyway, leading to a `net::ERR_UNKNOWN_URL_SCHEME` error page. This hard stop prevents the website's fallback script from ever running, leaving the user unable to play the video.

**The Solution**
The fix is a minor but crucial change in the `shouldOverrideUrlLoading` method within `MainActivity.kt`.

By changing the return value from `false` to `true` in the else block (which is executed when `intent.resolveActivity()` returns `null`), we instruct the webview to ignore the unhandled URL scheme instead of trying to load it.

This change makes the Android TV behavior consistent with the mobile behavior, allowing the website's video player to use its intended fallback and play the content successfully.

**How to Test This Change**
1. Install the app without the fix on an Android TV or Google TV device.
2. Navigate to the following URL: `https://fmoviesunblocked.net/spa/videoPlayPage/movies/forrest-gump-omjDmakRI3?id=50406015359143712&type=/movie/detail&lang=en`
3. Click the play button on the video player.
4. Observe: The browser will display a "Webpage not available" error (`net::ERR_UNKNOWN_URL_SCHEME`).
5. Now, install the app with this fix applied.
6. Repeat steps 2 and 3.
7. Observe: The video will now play correctly after a brief "Unable to find right app to open" toast message is displayed.

This simple change significantly improves compatibility with modern websites and enhances the user experience on TV devices.